### PR TITLE
Manually execute chronyc lookup

### DIFF
--- a/plugins/inputs/chrony/chrony.go
+++ b/plugins/inputs/chrony/chrony.go
@@ -33,7 +33,7 @@ func (*Chrony) SampleConfig() string {
   `
 }
 
-func (c *Chrony) Init() error {
+func (c *Chrony) init() error {
 	var err error
 	c.path, err = exec.LookPath("chronyc")
 	if err != nil {
@@ -43,6 +43,12 @@ func (c *Chrony) Init() error {
 }
 
 func (c *Chrony) Gather(acc telegraf.Accumulator) error {
+	//Manually execute chronyc lookup
+	err := c. init() 
+        if err != nil {
+		return err
+	}
+
 	flags := []string{}
 	if !c.DNSLookup {
 		flags = append(flags, "-n")


### PR DESCRIPTION
Manually execute chronyc lookup

fix bug: inputs.chrony :Init function is not executed resulting in empty path
#8503
